### PR TITLE
Workflow to trigger build of OpenEVSE WiFi firmware when changes are made to the GUI

### DIFF
--- a/.github/workflows/build_firmware.yaml
+++ b/.github/workflows/build_firmware.yaml
@@ -18,5 +18,6 @@ jobs:
         with:
           workflow: Build/Release OpenEVSE
           repo: OpenEVSE/ESP32_WiFi_V4.x
+          ref: build_v2_gui
           token: ${{ secrets.PERSONAL_TOKEN }}
           inputs: '{ "v2_ref": "${{ github.ref_name }}" }'

--- a/.github/workflows/build_firmware.yaml
+++ b/.github/workflows/build_firmware.yaml
@@ -1,0 +1,22 @@
+---
+
+name: Build OpenEVSE firmware
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Invoke workflow in OpenEVSE repo
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          workflow: Build/Release OpenEVSE
+          repo: OpenEVSE/ESP32_WiFi_V4.x
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          inputs: '{ "v2_ref": "${{ github.ref_name }}" }'


### PR DESCRIPTION
This work flow will trigger a (re)build of the OpenEVSE WiFi firmware when changes are made on this repo including PRs. This should allow for greater access to test binaries.

This will need a personal access token setting up with access to run the [Build/Release OpenEVSE](https://github.com/OpenEVSE/ESP32_WiFi_V4.x/actions/workflows/build.yaml) saved as the repository secret `PERSONAL_TOKEN`. @KipK Do you have access to manually trigger that workflow? If so you can create a legacy/classic PAT and add the secret. If not I have asked Chris to enable the PATs on the OpenEVSE org (OpenEVSE/[ESP32_WiFi_V4.x#510) and I will create a PAT for you.