### PR TITLE
Updated to trigger the builds from the `master` branch

### DIFF
--- a/.github/workflows/build_firmware.yaml
+++ b/.github/workflows/build_firmware.yaml
@@ -18,6 +18,6 @@ jobs:
         with:
           workflow: Build/Release OpenEVSE
           repo: OpenEVSE/ESP32_WiFi_V4.x
-          ref: build_v2_gui
+          ref: master
           token: ${{ secrets.PERSONAL_TOKEN }}
           inputs: '{ "v2_ref": "${{ github.ref_name }}" }'


### PR DESCRIPTION
Now various workflows have been merged to the OpenEVSE master we can trigger the builds from the `master` branch to ensure the latest firmware code.